### PR TITLE
fix: Flake template input references github repo.

### DIFF
--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -3,7 +3,7 @@
 
   # Add all your dependencies here
   inputs = {
-    blueprint.url = "path:../..";
+    blueprint.url = "github:numtide/blueprint";
   };
 
   # Keep the magic invocations to minimum.


### PR DESCRIPTION
Input URL specified in the flake template should reference the authoritative GitHub repository.