### PR TITLE
feat: allow extra args to be passed

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -26,6 +26,19 @@ Those take the following arguments:
 * `flake`: points to the current flake. It's a shorthand for `inputs.self`.
 * `pkgs`: and instance of nixpkgs, see [configuration](configuration.md) on how it's configured.
 
+In addition to the standard arguments, you can specify additional arguments to be passed by specifying them as `extraArgs`:
+
+```nix
+outputs =
+  inputs:
+  inputs.blueprint {
+    inherit inputs;
+    extraArgs = {
+      lib = inputs.nixpkgs.lib.extend (import ./lib.nix);
+    };
+  };
+```
+
 ## Mapping
 
 ### `devshell.nix`

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -11,6 +11,7 @@ let
       inputs,
       systems,
       nixpkgs,
+      extraArgs,
     }:
     let
       # make compatible with github:nix-systems/default
@@ -41,7 +42,7 @@ let
                 inherit system;
                 config = nixpkgs.config;
               };
-        }
+        } // extraArgs
       );
     in
     f: lib.genAttrs sys (system: f args.${system});
@@ -119,11 +120,13 @@ let
       },
       # The systems to generate the flake for
       systems ? inputs.systems or bpInputs.systems,
+      # Extra args to be passed in perSystem calls
+      extraArgs ? {}
     }:
     (
       { inputs }:
       let
-        eachSystem = mkEachSystem { inherit inputs nixpkgs systems; };
+        eachSystem = mkEachSystem { inherit inputs nixpkgs systems extraArgs; };
 
         src =
           if prefix == null then


### PR DESCRIPTION
I tend to customise `nixpkgs.lib` in my projects using extensions. To accommodate this in a 'blueprint' style I've added `extraArgs` rather than trying to further customise `nixpkgs`. This has the added benefit of accommodating wider use cases. 

```nix
  outputs =
    inputs:
    inputs.blueprint {
      inherit inputs;
      extraArgs = {
        lib = inputs.nixpkgs.lib.extend (import ./lib.nix);
      };
    };
```