### PR TITLE
top-level refactor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,6 @@ What it's bad for:
 * Darwin configurations
 * devshell
 
-## Packages folder
-
-If the ./pkgs folder exists, load every sub-folder in it and map it to the `packages` output.
-
-Each sub-folder should contain a `default.nix`, with the following function
-signature:
-
-* pname: name of the folder. Useful to inject back.
-* all the inputs
-
 ## How to support overrides?
 
 Don't

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What's blueprint?
 
-Blueprint is a light framework that replaces Nix glue code with a regular folder structure. Focus on deploying your infrastructure / package sets instead of reinventing the wheel.
+Blueprint replaces Nix glue code with a regular folder structure. Focus on deploying your infrastructure / package sets instead of reinventing the wheel.
 
 The ambition is to handle all the workflows to reduce the cost of self-hosting infrastructure (we're not quite there yet).
 
@@ -27,18 +27,20 @@ In some ways, this is the spiritual successor to `flake-utils`, my first
 attempt at making flakes easier to use.
 
 What it's good for:
+
 * Home and SME configurations
 * Package sets
 
 What it's bad for:
+
 * Complicated setups (although we try to provide gracefull fallback)
 * Developer environments (see devenv.sh)
 
 ## Design principles
 
+* User workflows come first.
 * KISS. We don't need complicated module systems with infinite recursions.
 * 1:1 mapping. Keep the mapping between attributes predictable.
-* Think about user workflows.
 
 ## Features
 
@@ -53,14 +55,6 @@ What it's bad for:
 * Darwin modules
 * Darwin configurations
 * devshell
-
-## Blacklisted inputs
-
-In order to avoid name clashes, avoid loading inputs with the following names:
-* lib
-* pname
-* system
-* pkgs
 
 ## Packages folder
 
@@ -80,12 +74,9 @@ Don't
 
 Don't
 
-
 ## Related projects
 
 * [flake-utils](https://github.com/numtide/flake-utils) the OG for flake libraries.
-* [flake-utils-plus]() extending flake-utils with more stuff.
 * [flake-parts](https://flake.parts) uses the Nix module system. It's too complicated for my taste.
-* [std]() ??
-* [snowflake-lib](TODO)
-
+* [std](https://github.com/divnix/std)
+* [snowflake-lib](https://github.com/snowfallorg/lib)

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,8 @@
   outputs =
     inputs:
     let
-      # use self to create self
-      blueprint = import ./lib inputs;
+      # Use self to create self
+      blueprint = import ./lib { inherit inputs; };
     in
     blueprint { inherit inputs; };
 }

--- a/formatter.nix
+++ b/formatter.nix
@@ -1,0 +1,65 @@
+{
+  pname,
+  pkgs,
+  flake,
+}:
+let
+  formatter = pkgs.writeShellApplication {
+    name = pname;
+
+    runtimeInputs = [
+      pkgs.deadnix
+      pkgs.nixfmt-rfc-style
+    ];
+
+    text = ''
+      set -euo pipefail
+      set -x
+
+      deadnix --no-lambda-pattern-names --edit "$@"
+
+      nixfmt "$@"
+    '';
+
+    meta = {
+      description = "format your project";
+    };
+  };
+
+  check =
+    pkgs.runCommand "format-check"
+      {
+        nativeBuildInputs = [
+          formatter
+          pkgs.git
+        ];
+
+        # only check on Linux
+        meta.platforms = pkgs.lib.platforms.linux;
+      }
+      ''
+        export HOME=$NIX_BUILD_TOP/home
+
+        # keep timestamps so that treefmt is able to detect mtime changes
+        cp --no-preserve=mode --preserve=timestamps -r ${flake} source
+        cd source
+        git init --quiet
+        git add .
+        shopt -s globstar
+        ${pname} **/*.nix
+        if ! git diff --exit-code; then
+          echo "-------------------------------"
+          echo "aborting due to above changes ^"
+          exit 1
+        fi
+        touch $out
+      '';
+in
+formatter
+// {
+  passthru = formatter.passthru // {
+    tests = {
+      check = check;
+    };
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,11 +1,7 @@
-{
-  nixos-rebuild,
-  runCommand,
-  writeShellApplication,
-}:
+{ pname, pkgs }:
 let
-  bp = writeShellApplication {
-    name = "bp";
+  bp = pkgs.writeShellApplication {
+    name = pname;
     runtimeInputs = [
 
     ];
@@ -18,7 +14,7 @@ let
           shift
           # Allow running the command as a user
           export SUDO_USER=1
-          echo ${nixos-rebuild}/bin/nixos-rebuild --flake . switch "$@"
+          echo ${pkgs.nixos-rebuild}/bin/nixos-rebuild --flake . switch "$@"
           ;;
         *)
           echo "Usage: bp [switch]"
@@ -36,7 +32,7 @@ bp
   # https://github.com/NixOS/nixpkgs/pull/320973
   passthru = bp.passthru // {
     tests = {
-      does-it-run = runCommand "bp-does-it-run" { } ''
+      does-it-run = pkgs.runCommand "bp-does-it-run" { } ''
         ${bp}/bin/bp --help > $out
       '';
     };

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -8,6 +8,6 @@
     blueprint.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  # Keep the magic invocations to minimum.
+  # Load the blueprint
   outputs = inputs: inputs.blueprint { inherit inputs; };
 }


### PR DESCRIPTION
For very simple flakes, it doesn't make sense to create a whole folder
structure.

ADDITIONS:

* Add a top-level package.nix that maps to `packages.<system>.default`
* Add a top-level formatter.nix that maps to `formatter.<system>` and `packages.<system>.formatter`.
* Load devshells from the devshells/ folder.

CHANGES:

* perSystem values now merge legacyPackages and packages in that order.
* packages are loaded with `callPackage`.

BREAKING:
* Remove `packages/<pname>/package.nix` as it makes the interface too
  complicated.
* lib/default.nix: take `{ flake, inputs }:` instead of `inputs`.