### PR TITLE
fix: fix the merge logic in the packages

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -33,7 +33,7 @@ bp
   passthru = bp.passthru // {
     tests = {
       does-it-run = pkgs.runCommand "bp-does-it-run" { } ''
-        ${bp}/bin/bp --help > $out
+        ${bp}/bin/${pname} --help > $out
       '';
     };
   };


### PR DESCRIPTION
It was merging on the systems level, and since Nix doesn't do a deep merge, it causes the last entry to win.