### PR TITLE
break(hosts): eval the host configs lazily

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -120,16 +120,25 @@ escape hatch, allowing the user complete control over `nixosSystem` or `darwinSy
 
 ```nix
 { flake, inputs, ... }:
-    inputs.nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
+{
+  class = "nixos";
+
+  value = inputs.nixpkgs-unstable.lib.nixosSystem {
+    system = "x86_64-linux";
         ...
-    }
+  };
+}
 ```
 
 Additional values passed:
 
 * `inputs` maps to the current flake inputs.
 * `flake` maps to `inputs.self`.
+
+Expected return value:
+
+* `class` - type of system. Currently "nixos" or "nix-darwin".
+* `value` - the evaluated system.
 
 Flake outputs:
 


### PR DESCRIPTION
Wrap the host configurations in one layer of indirection, so they only get evaluated when needed.

Fixes #2

@brianmcgee this is a breaking change for the `hosts/<hostname>/default.nix`