### PR TITLE
fix: hosts fallback

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -133,7 +133,7 @@ let
         let
           loadDefaultFn = { class, value }@inputs: inputs;
 
-          loadDefault = path: loadDefaultFn (import (path + "/default.nix") { inherit flake inputs; });
+          loadDefault = path: loadDefaultFn (import path { inherit flake inputs; });
 
           loadNixOS = path: {
             class = "nixos";


### PR DESCRIPTION
There was a duplicate `/default.nix` suffix which was breaking the import.

Signed-off-by: Brian McGee <brian@bmcgee.ie>
