### PR TITLE
Discover custom modules

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -199,7 +199,7 @@ let
         ) (lib.attrsToList hosts)
       );
 
-      moduleDirs = builtins.attrNames (builtins.readDir src + "/modules");
+      moduleDirs = builtins.attrNames (builtins.readDir (src + "/modules"));
       modules = builtins.listToAttrs (map (name: {name = name; value = importDir (src + "/modules/${name}") entriesPath; }) moduleDirs);
 
       #modules = {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -200,7 +200,7 @@ let
       );
 
       moduleDirs = builtins.attrNames (builtins.readDir src + "/modules");
-      modules = builtins.listToAttrs (map (name: {name = name; value = importDir (src + "/modules/${name}") entriesPath; }) modulesDirs);
+      modules = builtins.listToAttrs (map (name: {name = name; value = importDir (src + "/modules/${name}") entriesPath; }) moduleDirs);
 
       #modules = {
       #  common = importDir (src + "/modules/common") entriesPath;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -200,14 +200,12 @@ let
       );
 
       moduleDirs = builtins.attrNames (builtins.readDir (src + "/modules"));
-      modules = builtins.listToAttrs (map (name: {name = name; value = importDir (src + "/modules/${name}") entriesPath; }) moduleDirs);
-
-      #modules = {
-      #  common = importDir (src + "/modules/common") entriesPath;
-      #  darwin = importDir (src + "/modules/darwin") entriesPath;
-      #  home = importDir (src + "/modules/home") entriesPath;
-      #  nixos = importDir (src + "/modules/nixos") entriesPath;
-      #};
+      modules = builtins.listToAttrs (
+        map (name: {
+          name = name;
+          value = importDir (src + "/modules/${name}") entriesPath;
+        }) moduleDirs
+      );
     in
     # FIXME: maybe there are two layers to this. The blueprint, and then the mapping to flake outputs.
     {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -199,12 +199,15 @@ let
         ) (lib.attrsToList hosts)
       );
 
-      modules = {
-        common = importDir (src + "/modules/common") entriesPath;
-        darwin = importDir (src + "/modules/darwin") entriesPath;
-        home = importDir (src + "/modules/home") entriesPath;
-        nixos = importDir (src + "/modules/nixos") entriesPath;
-      };
+      moduleDirs = builtins.attrNames (builtins.readDir src + "/modules");
+      modules = builtins.listToAttrs (map (name: {name = name; value = importDir (src + "/modules/${name}") entriesPath; }) modulesDirs);
+
+      #modules = {
+      #  common = importDir (src + "/modules/common") entriesPath;
+      #  darwin = importDir (src + "/modules/darwin") entriesPath;
+      #  home = importDir (src + "/modules/home") entriesPath;
+      #  nixos = importDir (src + "/modules/nixos") entriesPath;
+      #};
     in
     # FIXME: maybe there are two layers to this. The blueprint, and then the mapping to flake outputs.
     {


### PR DESCRIPTION
Fixes the issue mentioned in #33 by picking up all directories in `src + /modules` as modules