### PR TITLE
Add standalone home-manager support

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -165,7 +165,7 @@ Additonal values passed:
 
 * `inputs` maps to the current flake inputs.
 * `flake` maps to `inputs.self`.
-* `perSystem`: contains the packages of all the inputs, filtered per sysstem.
+* `pkgs` an instance of nixpkgs, see [configuration](configuration.md) on how it's configured.* `perSystem`: contains the packages of all the inputs, filtered per sysstem.
     Eg: `perSystem.nixos-anywhere.default` is a shorthand for `inputs.nixos-anywhere.packages.<system>.default`.
 
 Flake outputs:
@@ -175,7 +175,7 @@ Flake outputs:
 ##### home-manager example
 
 ```nix
-{ flake, inputs, perSystem }:
+{ flake, inputs, pkgs, perSystem }:
 {
   imports = [
     flake.modules.home.zsh

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -170,7 +170,7 @@ Additonal values passed:
 
 Flake outputs:
 
-* `homeConfigurations.<name>`
+* `homeConfigurations."<name>@<system>"`
 
 ##### home-manager example
 

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -4,6 +4,7 @@
 
 * `devshells/` for devshells.
 * `hosts/` for machine configurations.
+* `homes/` for standalone home-manager configurations 
 * `lib/` for Nix functions.
 * `modules/` for NixOS and other modules.
 * `packages/` for packages.
@@ -152,6 +153,65 @@ Flake outputs:
 
 > Depending on the system type returned, the flake outputs will be the same as detailed for NixOS or Darwin above.
 
+### `homes/<name>/(default.nix|home.nix)`
+
+Each folder contains a standalone home-manager configuration:
+
+#### `home.nix`
+
+Evaluates to a standalone home-manager configuration.
+
+Additonal values passed:
+
+* `inputs` maps to the current flake inputs.
+* `flake` maps to `inputs.self`.
+* `perSystem`: contains the packages of all the inputs, filtered per sysstem.
+    Eg: `perSystem.nixos-anywhere.default` is a shorthand for `inputs.nixos-anywhere.packages.<system>.default`.
+
+Flake outputs:
+
+* `homeConfigurations.<name>`
+
+##### home-manager example
+
+```nix
+{ flake, inputs, perSystem }:
+{
+  imports = [
+    flake.modules.home.zsh
+  ];
+
+  home.username = "myUser";
+  home.homeDirectory = "/home/myUser";
+}
+```
+
+#### `default.nix`
+
+If present, this file takes precedence over `home.nix` and is designed as an escape hatch, allowing the user complete control over `homeManagerConfiguration` calls.
+
+```nix
+{ flake, inputs, ... }:
+{
+  value = inputs.home-manager.lib.homeManagerConfiguration {
+    home.username = "myUser";
+    ...
+  };
+}
+```
+
+Additional values passed:
+
+* `inputs` maps to the current flake inputs.
+* `flake` maps to `inputs.self`.
+
+Expected return value:
+
+* `value` - the evaluated home-manager configuration.
+
+Flake outputs:
+* `homeConfigurations.<name>`
+
 ### `lib/default.nix`
 
 Loaded if it exists.
@@ -178,6 +238,7 @@ Where the type can be:
 
 * "nixos" → `nixosModules.<name>`
 * "darwin" → `darwinModules.<name>`
+* "home" → `homeModules.<name>`
 
 These and other unrecognized types also make to `modules.<type>.<name>`.
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -176,16 +176,17 @@ let
         lib.mapAttrs loadHome entries
       );
 
-      flattenUsernameSystem = attrs: builtins.foldl' (acc: name:
-        let
-          systems = attrs.${name};
-        in
-          builtins.foldl' (acc2: system:
-            acc2 // {
-              "${name}@${system}" = systems.${system};
-            }
-          ) acc (builtins.attrNames systems)
-      ) {} (builtins.attrNames attrs);
+      flattenUsernameSystem =
+        attrs:
+        builtins.foldl' (
+          acc: name:
+          let
+            systems = attrs.${name};
+          in
+          builtins.foldl' (acc2: system: acc2 // { "${name}@${system}" = systems.${system}; }) acc (
+            builtins.attrNames systems
+          )
+        ) { } (builtins.attrNames attrs);
 
       homesBySystem = flattenUsernameSystem homes;
 
@@ -309,7 +310,7 @@ let
 
       darwinConfigurations = lib.mapAttrs (_: x: x.value) (hostsByCategory.darwinConfigurations or { });
       nixosConfigurations = lib.mapAttrs (_: x: x.value) (hostsByCategory.nixosConfigurations or { });
-      homeConfigurations = lib.mapAttrs(_: x: x.value) homesBySystem;
+      homeConfigurations = lib.mapAttrs (_: x: x.value) homesBySystem;
 
       inherit modules;
       darwinModules = modules.darwin;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -156,6 +156,7 @@ let
                 perSystemModule
                 path
               ];
+              extraSpecialArgs = specialArgs;
               inherit pkgs;
             };
           };          
@@ -187,6 +188,7 @@ let
                 perSystemModule
                 path
               ];
+              inherit specialArgs;
             };
           };
 


### PR DESCRIPTION
Adds support for standalone home-manager configurations.

These configurations are discovered from `homes/<username>/(default.nix|home.nix)`, similarly to how systems are discovered from `hosts/<hostname>/(default.nix|configuration.nix|darwin-configuration.nix)`
- home.nix: standalone home-manager configuration
- default.nix: an "escape hatch" giving the user complete control over `homeManagerConfiguration` calls

This issue was my attempt to add support in the way described by #35, however I wasn't able to do it exactly as I wanted. Home manager configs need system set to pass pkgs as an argument to HM modules. Instead of adding an option to specify the system of a particular home-manager profile, I used the existing `eachSystem` function to build profiles for each system specified by the user's `systems` flake input.

The home-manager CLI expects the flake outputs `homeConfigurations.<name>` not `homeConfigurations.<system>.<name>`. To get around this, I merge the nested attrsets so that the output becomes `homeConfigurations."<name>@<system>"`. An example command to build the profile would be `home-manager build --flake .#"agaia@x86_64-linux"`.

I don't love this solution TBH, but I wasn't sure of a good way for the user to specify. It crossed my mind to add a nested folder specifying the system (`<repo>/homes/<system>/<name>`), but I didn't like that either.



If this HM issue ever gets taken up, it could add some clarity on what to do. https://github.com/nix-community/home-manager/issues/2161_