### PR TITLE
feat(template): add a devshell to the default template

### DIFF
--- a/templates/default/.envrc
+++ b/templates/default/.envrc
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Used by https://direnv.net
+
+# Automatically reload when this file changes
+watch_file devshell.nix
+
+# Load `nix develop`
+use flake
+
+# Extend the environment with per-user overrides
+source_env_if_exists .envrc.local

--- a/templates/default/.gitignore
+++ b/templates/default/.gitignore
@@ -1,0 +1,6 @@
+# direnv
+.direnv/
+
+# nix
+result
+result-*

--- a/templates/default/devshell.nix
+++ b/templates/default/devshell.nix
@@ -1,0 +1,13 @@
+{ pkgs }:
+pkgs.mkShell {
+  # Add build dependencies
+  packages = [ ];
+
+  # Add environment variables
+  env = { };
+
+  # Load custom bash code
+  shellHook = ''
+
+  '';
+}

--- a/templates/default/flake.lock
+++ b/templates/default/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1724053269,
+        "narHash": "sha256-DinmPyxmUSLjBUYMe3eK0GKykwe33vWbVTmp7++P4Ng=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "766302be9063650ca6578e5ba09cc4260b0da29c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
Some minimal default to get start with blueprint + direnv with:

    nix flake init --template numtide/blueprint