### PR TITLE
feat: pick up all modules in modules/ dir

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -174,10 +174,13 @@ Eg:
 
 ### `modules/<type>/(<name>|<name>.nix)`
 
-Where the type can be:
+Where the type can be any folder name.
 
-* "nixos" → `nixosModules.<name>`
+For the following folder names, we also map them to the following outputs:
+
 * "darwin" → `darwinModules.<name>`
+* "home" → `homeModules.<name>`
+* "nixos" → `nixosModules.<name>`
 
 These and other unrecognized types also make to `modules.<type>.<name>`.
 


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/numtide/blueprint/issues/33 by picking up all directories in src + /modules as modules.

Follow-up to https://github.com/numtide/blueprint/pull/34