### PR TITLE
fix: filterAttrs is not a builtin

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -203,7 +203,7 @@ let
         let
           path = src + "/modules";
           moduleDirs = builtins.attrNames (
-            builtins.filterAttrs (_name: value: value == "directory") (builtins.readDir path)
+            lib.filterAttrs (_name: value: value == "directory") (builtins.readDir path)
           );
         in
         lib.optionalAttrs (builtins.pathExists path) (


### PR DESCRIPTION
...at least in nix 2.18 and lix.

Fixes main branch, which is broken since https://github.com/numtide/blueprint/pull/40