### PR TITLE
fix: better handling of meta.platforms

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -106,7 +106,11 @@ let
   filterPlatforms =
     system: attrs:
     lib.filterAttrs (
-      _: x: if x.meta ? platforms then lib.elem system x.meta.platforms else true # keep every package that has no meta.platforms
+      _: x:
+      if (x.meta.platforms or [ ]) == [ ] then
+        true # keep every package that has no meta.platforms
+      else
+        lib.elem system x.meta.platforms
     ) attrs;
 
   mkBlueprint' =


### PR DESCRIPTION
If a package did not declare a `meta` field, commands such as `nix flake check` would fail due to `filterPlatforms` attempting
to read non-existent attributes. We now traverse the path with `hasAttrByPath` in order to avoid the assumption of attributes existing.