### PR TITLE
fix(lib/checks): import path of each check

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -385,7 +385,26 @@ let
               )
             ))
             # load checks from the /checks folder. Those take precedence over the others.
-            (optionalPathAttrs (src + "/checks") (path: importDir path lib.id))
+            (optionalPathAttrs (src + "/checks") (
+              path:
+              let
+                importChecksFn = lib.mapAttrs (
+                  pname:
+                  { type, path }:
+                  import path {
+                    inherit
+                      pname
+                      flake
+                      inputs
+                      system
+                      pkgs
+                      ;
+                  }
+                );
+              in
+
+              (importDir path importChecksFn)
+            ))
           ]
           ++ (lib.optional (inputs.self.lib.tests or { } != { }) {
             lib-tests = pkgs.runCommandLocal "lib-tests" { nativeBuildInputs = [ pkgs.nix-unit ]; } ''

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -385,25 +385,27 @@ let
               )
             ))
             # load checks from the /checks folder. Those take precedence over the others.
-            (optionalPathAttrs (src + "/checks") (
-              path:
-              let
-                importChecksFn = lib.mapAttrs (
-                  pname:
-                  { type, path }:
-                  import path {
-                    inherit
-                      pname
-                      flake
-                      inputs
-                      system
-                      pkgs
-                      ;
-                  }
-                );
-              in
+            (filterPlatforms system (
+              optionalPathAttrs (src + "/checks") (
+                path:
+                let
+                  importChecksFn = lib.mapAttrs (
+                    pname:
+                    { type, path }:
+                    import path {
+                      inherit
+                        pname
+                        flake
+                        inputs
+                        system
+                        pkgs
+                        ;
+                    }
+                  );
+                in
 
-              (importDir path importChecksFn)
+                (importDir path importChecksFn)
+              )
             ))
           ]
           ++ (lib.optional (inputs.self.lib.tests or { } != { }) {


### PR DESCRIPTION
prior to this the values in the checks attrs weren't derivations.

---

~~marking as a draft as i'm still encountering an infinite recursion trying to use this.~~ 

the infinite recursion that i encountered is due to an intrinsic property of the module system, i.e. it's expected albeit not intuitive behavior. more in #56 