### PR TITLE
fix: resolve broken nix-darwin configurations

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -293,7 +293,7 @@ let
                 modules = [
                   perSystemModule
                   path
-                ] ++ mkHomeUsersModule hostname home-manager.nixosModules.default;
+                ] ++ mkHomeUsersModule hostname home-manager.darwinModules.default;
                 inherit specialArgs;
               };
             };


### PR DESCRIPTION
#57 introduced a subtle typo: darwinModules was changed to nixosModules. Easy to miss!