### PR TITLE
feat: populate template description using flake

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -482,8 +482,11 @@ let
           { path, type }:
           {
             path = path;
-            # FIXME: how can we add something more meaningful?
-            description = name;
+            description =
+              if builtins.pathExists (path + "/flake.nix") then
+                (import (path + "/flake.nix")).description or name
+              else
+                name;
           }
         ) entries
       );

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "my flake";
+  description = "Simple flake with a devshell";
 
   # Add all your dependencies here
   inputs = {


### PR DESCRIPTION
If a `description` is included in the flake, the description will be used as the template description. This makes the descriptions more meaningful without having to introduce an additional point of configuration.