### PR TITLE
feat: home configurations without hostname

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -128,10 +128,6 @@ let
         self = throw "self was renamed to flake";
       };
 
-      hmSpecialArgs = specialArgs // {
-        users = homesGeneric;
-      };
-
       inherit
         (mkEachSystem {
           inherit
@@ -169,7 +165,7 @@ let
             {
               imports = [ homeManagerModule ];
               home-manager.sharedModules = [ perSystemModule ];
-              home-manager.extraSpecialArgs = hmSpecialArgs;
+              home-manager.extraSpecialArgs = specialArgs;
               home-manager.users = homesNested.${hostname};
               home-manager.useGlobalPkgs = lib.mkDefault true;
               home-manager.useUserPackages = lib.mkDefault true;
@@ -244,7 +240,7 @@ let
             }:
             home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
-              extraSpecialArgs = hmSpecialArgs;
+              extraSpecialArgs = specialArgs;
               modules = [
                 perSystemModule
                 modulePath


### PR DESCRIPTION
This PR will be marked as draft until there's consensus on what the right design is and a solid implementation for it. **This PR only exists since I needed a place to put the to-do list**, and since the feature probably be merged in *some* form eventually :)

This might not be the final form this takes, so I'm not going to describe it in detail in the PR. The commit descriptions will be up to date.

To-do:
- [ ] Improve let-binding naming
- [ ] Verify generic home configs will warn users without a home-manager input
- [ ] Add test cases

See #74 for design considerations