### PR TITLE
feat: Load TOML shells with numtide/devshell

### DIFF
--- a/templates/toml-devenvs/checks/bye-devshell.nix
+++ b/templates/toml-devenvs/checks/bye-devshell.nix
@@ -1,0 +1,14 @@
+{ pkgs, inputs, ... }:
+let
+  # defined in devshells/bye.nix
+  shell = inputs.self.devShells.${pkgs.system}.bye;
+in
+pkgs.stdenvNoCC.mkDerivation {
+  name = "hello-devshell";
+  phases = [ "check" ];
+  check = ''
+    source ${shell}/entrypoint
+    menu # log the shell menu
+    check | tee $out
+  '';
+}

--- a/templates/toml-devenvs/checks/default-devshell.nix
+++ b/templates/toml-devenvs/checks/default-devshell.nix
@@ -1,0 +1,14 @@
+{ pkgs, inputs, ... }:
+let
+  # defined in devshell.toml at root of this flake.
+  shell = inputs.self.devShells.${pkgs.system}.default;
+in
+pkgs.stdenvNoCC.mkDerivation {
+  name = "default-devshell";
+  phases = [ "check" ];
+  check = ''
+    source ${shell}/entrypoint
+    menu # log the shell menu
+    hello | tee $out
+  '';
+}

--- a/templates/toml-devenvs/devshell.toml
+++ b/templates/toml-devenvs/devshell.toml
@@ -1,0 +1,1 @@
+imports = ["./devshells/hello.toml"]

--- a/templates/toml-devenvs/devshells/bye.nix
+++ b/templates/toml-devenvs/devshells/bye.nix
@@ -1,0 +1,5 @@
+{ perSystem, ... }:
+perSystem.devshell.mkShell {
+  imports = [ (perSystem.devshell.importTOML ./bye.toml) ];
+  devshell.packages = [ perSystem.self.bye ];
+}

--- a/templates/toml-devenvs/devshells/bye.toml
+++ b/templates/toml-devenvs/devshells/bye.toml
@@ -1,0 +1,5 @@
+imports = [ "./hello.toml" ]
+
+[[commands]]
+name = "check"
+command = "bye $(hello)" 

--- a/templates/toml-devenvs/devshells/hello.toml
+++ b/templates/toml-devenvs/devshells/hello.toml
@@ -1,0 +1,2 @@
+[[commands]]
+package = "hello"

--- a/templates/toml-devenvs/flake.nix
+++ b/templates/toml-devenvs/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "TOML devshells";
+
+  # Add all your dependencies here
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    blueprint.url = "github:numtide/blueprint";
+    blueprint.inputs.nixpkgs.follows = "nixpkgs";
+    devshell.url = "github:numtide/devshell";
+    devshell.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  # Load the blueprint
+  outputs = inputs: inputs.blueprint { inherit inputs; };
+}

--- a/templates/toml-devenvs/packages/bye.nix
+++ b/templates/toml-devenvs/packages/bye.nix
@@ -1,0 +1,1 @@
+{ pkgs, ... }: pkgs.writeShellScriptBin "bye" ''echo Goodbye "$@"''


### PR DESCRIPTION
This changeset loads TOML devshells using `numtide/blueprint`.

The only requirement is that the user's flake has an `input.devshell` otherwise they will be told to add it.

I still have to add documentation for this feature.

Basically, if you have any `/devshells/*.toml` or `/devshell.toml` they will be loaded with something like `devshell.fromTOML` but that allows custom nix modules to also access packages from `perSystem.self`. 

I'm using this branch at my local nixos setup, see https://github.com/vic/vix/tree/main/devshells for some devshells I've defined, particularly `nixos.toml` that imports `nixos/leader.nix` which can access packages defined in the flake itself.

The old behaviour is still preserved, and any `.nix` files will still be loaded as-is. So those nix files are responsible for using either nixpkgs's mkShell or devshell's one. For example, my `scala3.nix` customizes the JRE for some tools.

I'll be adding documentation tomorrow, and would love if you could direct me on how to write tests for this functionality.

Cheers :)