### PR TITLE
Add example template on how to reuse nixos and home-manager modules.

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -201,6 +201,7 @@ Additional values passed:
 * `flake` maps to `inputs.self`.
 * `perSystem`: contains the packages of all the inputs, filtered per system.
     Eg: `perSystem.nixos-anywhere.default` is a shorthand for `inputs.nixos-anywhere.packages.<system>.default`.
+* `hostConfig`: the host nixos/nix-darwin configuration.
 
 > The simplest way to have a common/shared user configuration between multiple systems is to create a
 > module at `modules/home/<name>.nix` ([docs](#modulestypenamenamenix)), and import that module

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -161,11 +161,13 @@ let
         hostname: homeManagerModule:
         let
           module =
-            { perSystem, ... }:
+            { perSystem, config, ... }:
             {
               imports = [ homeManagerModule ];
               home-manager.sharedModules = [ perSystemModule ];
-              home-manager.extraSpecialArgs = specialArgs;
+              home-manager.extraSpecialArgs = specialArgs // {
+                hostConfig = config;
+              };
               home-manager.users = homesNested.${hostname};
               home-manager.useGlobalPkgs = lib.mkDefault true;
               home-manager.useUserPackages = lib.mkDefault true;

--- a/templates/nixos-and-darwin-shared-homes/README.md
+++ b/templates/nixos-and-darwin-shared-homes/README.md
@@ -1,0 +1,14 @@
+This template shows how you can define and reuse nixos and home-manager modules.
+
+
+This flake defines two hosts `my-darwin` and `my-nixos`, both importing a
+shared `modules/nixos/host-shared.nix` module between them.
+
+
+Also, both hosts define a `me` user and their home-managed configuration
+simply imports `modules/homes/home-shared.nix`.
+
+
+The idea is you can use this example to get started on how to share
+configurations between different system and home environments on different
+hosts.

--- a/templates/nixos-and-darwin-shared-homes/flake.nix
+++ b/templates/nixos-and-darwin-shared-homes/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Sharing home-manager modules between nixos and darwin";
+
+  # Add all your dependencies here
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+
+    blueprint.url = "github:numtide/blueprint";
+    blueprint.inputs.nixpkgs.follows = "nixpkgs";
+
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    nix-darwin.url = "github:LnL7/nix-darwin";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  # Load the blueprint
+  outputs = inputs: inputs.blueprint { inherit inputs; };
+}

--- a/templates/nixos-and-darwin-shared-homes/hosts/my-darwin/darwin-configuration.nix
+++ b/templates/nixos-and-darwin-shared-homes/hosts/my-darwin/darwin-configuration.nix
@@ -1,0 +1,11 @@
+{ pkgs, inputs, ... }:
+{
+
+  imports = [ inputs.self.nixosModules.host-shared ];
+
+  nixpkgs.hostPlatform = "aarch64-darwin";
+
+  users.users.me.home = /Users/me;
+
+  system.stateVersion = 6; # initial nix-darwin state
+}

--- a/templates/nixos-and-darwin-shared-homes/hosts/my-darwin/users/me/home-configuration.nix
+++ b/templates/nixos-and-darwin-shared-homes/hosts/my-darwin/users/me/home-configuration.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  inputs,
+  hostConfig,
+  ...
+}:
+{
+
+  imports = [ inputs.self.homeModules.home-shared ];
+}

--- a/templates/nixos-and-darwin-shared-homes/hosts/my-nixos/configuration.nix
+++ b/templates/nixos-and-darwin-shared-homes/hosts/my-nixos/configuration.nix
@@ -1,0 +1,16 @@
+{ pkgs, inputs, ... }:
+{
+
+  imports = [ inputs.self.nixosModules.host-shared ];
+
+  nixpkgs.hostPlatform = "x86_64-linux";
+
+  # on nixos this either isNormalUser or isSystemUser is required to create the user.
+  users.users.me.isNormalUser = true;
+
+  # for testing purposes only, remove on bootable hosts.
+  boot.loader.grub.enable = pkgs.lib.mkDefault false;
+  fileSystems."/".device = pkgs.lib.mkDefault "/dev/null";
+
+  system.stateVersion = "25.05"; # initial nixos state
+}

--- a/templates/nixos-and-darwin-shared-homes/hosts/my-nixos/users/me/home-configuration.nix
+++ b/templates/nixos-and-darwin-shared-homes/hosts/my-nixos/users/me/home-configuration.nix
@@ -1,0 +1,5 @@
+{ pkgs, inputs, ... }:
+{
+
+  imports = [ inputs.self.homeModules.home-shared ];
+}

--- a/templates/nixos-and-darwin-shared-homes/modules/home/home-shared.nix
+++ b/templates/nixos-and-darwin-shared-homes/modules/home/home-shared.nix
@@ -1,0 +1,15 @@
+{ pkgs, hostConfig, ... }:
+{
+
+  # only available on linux, disabled on macos
+  services.ssh-agent.enable = pkgs.stdenv.isLinux;
+
+  home.packages =
+    [ pkgs.ripgrep ]
+    ++ (
+      # you can access the host configuration using hostConfig.
+      pkgs.lib.optionals (hostConfig.programs.vim.enable && pkgs.stdenv.isDarwin) [ pkgs.skhd ]
+    );
+
+  home.stateVersion = "24.11"; # initial home-manager state
+}

--- a/templates/nixos-and-darwin-shared-homes/modules/nixos/host-shared.nix
+++ b/templates/nixos-and-darwin-shared-homes/modules/nixos/host-shared.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+
+  programs.vim.enable = true;
+
+  # you can check if host is darwin by using pkgs.stdenv.isDarwin
+  environment.systemPackages = [
+    pkgs.btop
+  ] ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.xbar ]);
+}


### PR DESCRIPTION
This also serves as CI test for checking that blueprint correctly integrates home-manager, nixos and nix-darwin configurations.

A new feature is also tested: on host nested home-configurations you can now access `hostConfig` which provides a way to enable things on home-managed environment based on the host system-wide config.