### PR TITLE
Remove `hostConfig` in homes specialArgs.

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -201,12 +201,14 @@ Additional values passed:
 * `flake` maps to `inputs.self`.
 * `perSystem`: contains the packages of all the inputs, filtered per system.
     Eg: `perSystem.nixos-anywhere.default` is a shorthand for `inputs.nixos-anywhere.packages.<system>.default`.
-* `hostConfig`: the host nixos/nix-darwin configuration.
+* other provided module arguments.
+    Eg: home-manager provides `osConfig`, the host nixos/nix-darwin configuration.
 
 > The simplest way to have a common/shared user configuration between multiple systems is to create a
 > module at `modules/home/<name>.nix` ([docs](#modulestypenamenamenix)), and import that module
 > from `inputs.self.homeModules.<name>` for each user that should inherit it. This pattern makes
 > it easy to apply system-specific customizations on top of a shared, generic configuration.
+> An example of this setup is shown in the following template: `templates/nixos-and-darwin-shared-homes`.
 
 #### NixOS and nix-darwin
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -165,9 +165,7 @@ let
             {
               imports = [ homeManagerModule ];
               home-manager.sharedModules = [ perSystemModule ];
-              home-manager.extraSpecialArgs = specialArgs // {
-                hostConfig = config;
-              };
+              home-manager.extraSpecialArgs = specialArgs;
               home-manager.users = homesNested.${hostname};
               home-manager.useGlobalPkgs = lib.mkDefault true;
               home-manager.useUserPackages = lib.mkDefault true;

--- a/templates/nixos-and-darwin-shared-homes/hosts/my-darwin/users/me/home-configuration.nix
+++ b/templates/nixos-and-darwin-shared-homes/hosts/my-darwin/users/me/home-configuration.nix
@@ -1,9 +1,4 @@
-{
-  pkgs,
-  inputs,
-  hostConfig,
-  ...
-}:
+{ pkgs, inputs, ... }:
 {
 
   imports = [ inputs.self.homeModules.home-shared ];

--- a/templates/nixos-and-darwin-shared-homes/modules/home/home-shared.nix
+++ b/templates/nixos-and-darwin-shared-homes/modules/home/home-shared.nix
@@ -1,4 +1,4 @@
-{ pkgs, hostConfig, ... }:
+{ pkgs, osConfig, ... }:
 {
 
   # only available on linux, disabled on macos
@@ -7,8 +7,8 @@
   home.packages =
     [ pkgs.ripgrep ]
     ++ (
-      # you can access the host configuration using hostConfig.
-      pkgs.lib.optionals (hostConfig.programs.vim.enable && pkgs.stdenv.isDarwin) [ pkgs.skhd ]
+      # you can access the host configuration using osConfig.
+      pkgs.lib.optionals (osConfig.programs.vim.enable && pkgs.stdenv.isDarwin) [ pkgs.skhd ]
     );
 
   home.stateVersion = "24.11"; # initial home-manager state


### PR DESCRIPTION
`hostConfig` was introduced in #85, however as pointed out by @JumpIn-Git, home-manager already provides the same functionality via the `osConfig` module argument.

This PR removes `hostConfig`.

Also added a bit of documentation about the sharing-modules example.