### PR TITLE
fix: add perSystem to checks/ arguments

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -563,17 +563,7 @@ let
                 path:
                 let
                   importChecksFn = lib.mapAttrs (
-                    pname:
-                    { type, path }:
-                    import path {
-                      inherit
-                        pname
-                        flake
-                        inputs
-                        system
-                        pkgs
-                        ;
-                    }
+                    pname: { type, path }: import path (systemArgs.${system} // { inherit pname; })
                   );
                 in
 


### PR DESCRIPTION
docs claim that nix files in checks/ are called with all per-system arguments. That claim was not correct until this commit, as perSystem was missing.

fixes #79 