### PR TITLE
Revert "fix: don't reevaluate nixpkgs in nixosConfigurations"

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -165,30 +165,10 @@ let
         ;
 
       # Adds the perSystem argument to the NixOS and Darwin modules
-      perSystemArgsModule = system: {
-        _module.args.perSystem = systemArgs.${system}.perSystem;
-      };
-
-      # Shares pkgs with flake's, to avoid multiple nixpkgs reevaluations
       perSystemModule =
-        { config, lib, ... }:
+        { pkgs, ... }:
         {
-          imports = [ (perSystemArgsModule config.nixpkgs.hostPlatform.system) ];
-          nixpkgs.pkgs = lib.mkDefault systemArgs.${config.nixpkgs.hostPlatform.system}.pkgs;
-        };
-
-      # Same thing for home-manager
-      perSystemHMModule =
-        { osConfig, ... }:
-        {
-          imports = [ (perSystemArgsModule osConfig.nixpkgs.hostPlatform.system) ];
-        };
-
-      # Same thing for system manager
-      perSystemSMModule =
-        { config, lib, ... }:
-        {
-          imports = [ (perSystemArgsModule config.nixpkgs.hostPlatform) ];
+          _module.args.perSystem = systemArgs.${pkgs.system}.perSystem;
         };
 
       home-manager =
@@ -221,7 +201,7 @@ let
             { perSystem, config, ... }:
             {
               imports = [ homeManagerModule ];
-              home-manager.sharedModules = [ perSystemHMModule ];
+              home-manager.sharedModules = [ perSystemModule ];
               home-manager.extraSpecialArgs = specialArgs;
               home-manager.users = homesNested.${hostname};
               home-manager.useGlobalPkgs = lib.mkDefault true;
@@ -372,7 +352,7 @@ let
               class = "system-manager";
               value = system-manager.lib.makeSystemConfig {
                 modules = [
-                  perSystemSMModule
+                  perSystemModule
                   path
                 ];
                 extraSpecialArgs = specialArgs;


### PR DESCRIPTION
Reverts numtide/blueprint#93 as it causes infinite recursion for some users.