### PR TITLE
pass file-system-derived hostname to host configurations

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -126,7 +126,7 @@ command = "memcached"
 
 ### `hosts/<hostname>/(default.nix|configuration.nix|darwin-configuration.nix,system-configuration.nix)`
 
-Each folder contains either a NixOS or nix-darwin configuration:
+Each folder contains either a NixOS, [nix-darwin](https://github.com/LnL7/nix-darwin) or [system-manager](https://github.com/numtide/system-manager) configuration:
 
 #### `configuration.nix`
 
@@ -138,6 +138,7 @@ Additional values passed:
 * `flake` maps to `inputs.self`.
 * `perSystem`: contains the packages of all the inputs, filtered per system.
     Eg: `perSystem.nixos-anywhere.default` is a shorthand for `inputs.nixos-anywhere.packages.<system>.default`.
+* `hostName` as per the hosts directory name.
 
 Flake outputs:
 
@@ -182,6 +183,7 @@ Additional values passed:
 * `flake` maps to `inputs.self`.
 * `perSystem`: contains the packages of all the inputs, filtered per system.
     Eg: `perSystem.nixos-anywhere.default` is a shorthand for `inputs.nixos-anywhere.packages.<system>.default`.
+* `hostName` as per the hosts directory name.
 
 Flake outputs:
 
@@ -207,6 +209,7 @@ Additional values passed:
 * `flake` maps to `inputs.self`.
 * `perSystem`: contains the packages of all the inputs, filtered per system.
     Eg: `perSystem.nixos-anywhere.default` is a shorthand for `inputs.nixos-anywhere.packages.<system>.default`.
+* `hostName` as per the hosts directory name.
 
 Flake outputs:
 
@@ -234,6 +237,7 @@ Additional values passed:
 
 * `inputs` maps to the current flake inputs.
 * `flake` maps to `inputs.self`.
+* `hostName` as per the hosts directory name.
 
 Expected return value:
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -310,21 +310,21 @@ let
         let
           loadDefaultFn = { class, value }@inputs: inputs;
 
-          loadDefault = path: loadDefaultFn (import path { inherit flake inputs; });
+          loadDefault = hostName: path: loadDefaultFn (import path { inherit flake inputs hostName; });
 
-          loadNixOS = hostname: path: {
+          loadNixOS = hostName: path: {
             class = "nixos";
             value = inputs.nixpkgs.lib.nixosSystem {
               modules = [
                 perSystemModule
                 path
-              ] ++ mkHomeUsersModule hostname home-manager.nixosModules.default;
-              inherit specialArgs;
+              ] ++ mkHomeUsersModule hostName home-manager.nixosModules.default;
+              specialArgs = specialArgs // { inherit hostName; };
             };
           };
 
           loadNixDarwin =
-            hostname: path:
+            hostName: path:
             let
               nix-darwin =
                 inputs.nix-darwin
@@ -336,13 +336,13 @@ let
                 modules = [
                   perSystemModule
                   path
-                ] ++ mkHomeUsersModule hostname home-manager.darwinModules.default;
-                inherit specialArgs;
+                ] ++ mkHomeUsersModule hostName home-manager.darwinModules.default;
+                specialArgs = specialArgs // { inherit hostName; };
               };
             };
 
           loadSystemManager =
-            _hostname: path:
+            hostName: path:
             let
               system-manager =
                 inputs.system-manager
@@ -355,7 +355,7 @@ let
                   perSystemModule
                   path
                 ];
-                extraSpecialArgs = specialArgs;
+                extraSpecialArgs = specialArgs // { inherit hostName; };
               };
             };
 
@@ -363,7 +363,7 @@ let
             name:
             { path, type }:
             if builtins.pathExists (path + "/default.nix") then
-              loadDefault (path + "/default.nix")
+              loadDefault name (path + "/default.nix")
             else if builtins.pathExists (path + "/configuration.nix") then
               loadNixOS name (path + "/configuration.nix")
             else if builtins.pathExists (path + "/darwin-configuration.nix") then


### PR DESCRIPTION
This aims to provide the features asked for in #96 with two notable differences:

- we don't set any nixos options but empower users to do so by passing the hostname along
- we do so for nix-darwin and system-manager systems as well.

docs are updated to reflect the change.


cc @yajo 