### PR TITLE
Set perSystem using `nixpkgs.hostPlatform` instead of `pkgs.system`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -165,10 +165,26 @@ let
         ;
 
       # Adds the perSystem argument to the NixOS and Darwin modules
+      perSystemArgsModule = system: {
+        _module.args.perSystem = systemArgs.${system}.perSystem;
+      };
+
       perSystemModule =
-        { pkgs, ... }:
+        { config, lib, ... }:
         {
-          _module.args.perSystem = systemArgs.${pkgs.system}.perSystem;
+          imports = [ (perSystemArgsModule config.nixpkgs.hostPlatform.system) ];
+        };
+
+      perSystemHMModule =
+        { osConfig, ... }:
+        {
+          imports = [ (perSystemArgsModule osConfig.nixpkgs.hostPlatform.system) ];
+        };
+
+      perSystemSMModule =
+        { config, lib, ... }:
+        {
+          imports = [ (perSystemArgsModule config.nixpkgs.hostPlatform) ];
         };
 
       home-manager =
@@ -201,7 +217,7 @@ let
             { perSystem, config, ... }:
             {
               imports = [ homeManagerModule ];
-              home-manager.sharedModules = [ perSystemModule ];
+              home-manager.sharedModules = [ perSystemHMModule ];
               home-manager.extraSpecialArgs = specialArgs;
               home-manager.users = homesNested.${hostname};
               home-manager.useGlobalPkgs = lib.mkDefault true;
@@ -352,7 +368,7 @@ let
               class = "system-manager";
               value = system-manager.lib.makeSystemConfig {
                 modules = [
-                  perSystemModule
+                  perSystemSMModule
                   path
                 ];
                 extraSpecialArgs = specialArgs;


### PR DESCRIPTION
This is an adaption of commit f1dc2cd9ffc514a3e647b88ac11b189a11cc8144
without setting `nixpkgs.pkgs`.

By leaning on nixpkgs.hostPlatform, we allow the user to set
`nixpkgs.pkgs` themselves without breaking the evaluation.

We assume that every NixOS and other instances have this variable set.
