### PR TITLE
Pass nixpkgs.lib to lib/default.nix

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -488,7 +488,7 @@ let
         })
       );
 
-      lib = tryImport (src + "/lib") specialArgs;
+      lib = tryImport (src + "/lib") (specialArgs // {inherit (inputs.nixpkgs) lib;});
 
       # expose the functor to the top-level
       # FIXME: only if it exists


### PR DESCRIPTION
When blueprint imports `lib/default.nix`, it only passes inputs and flake. Nixpkgs lib will probaly be used in the function so we can pass it, since `inputs.nixpkgs.lib` doesn't depend on system and the `nixpkgs` input will always be available because the inputs of blueprint and the guest are combined.