### PR TITLE
add a minimal example for standalone home-manager.

### DIFF
--- a/templates/home-manager-standalone/flake.nix
+++ b/templates/home-manager-standalone/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
 
     blueprint = {
       url = "github:numtide/blueprint";
@@ -8,7 +8,7 @@
     };
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-24.11";
+      url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/templates/home-manager-standalone/flake.nix
+++ b/templates/home-manager-standalone/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-24.11";
+
+    blueprint = {
+      url = "github:numtide/blueprint";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    home-manager = {
+      url = "github:nix-community/home-manager/release-24.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    inputs.blueprint {
+      inherit inputs;
+    };
+}

--- a/templates/home-manager-standalone/hosts/myhost/users/me.nix
+++ b/templates/home-manager-standalone/hosts/myhost/users/me.nix
@@ -1,0 +1,6 @@
+{ perSystem, ... }:
+{
+  home.stateVersion = "24.11";
+
+  home.packages = [ perSystem.blueprint.docs ];
+}


### PR DESCRIPTION
It is related to https://github.com/numtide/blueprint/issues/102

This example is minimal flakes to check standalone home-manager.

```sh
home-manager switch --flake .
```

Because standalone home-manager and modular home-manager have different configuration parameters, you need to ensure that blueprint works correctly.