### PR TITLE
fix standalone homemanager

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -270,12 +270,13 @@ let
               username,
               modulePath,
               pkgs,
+              system,
             }:
             home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
               extraSpecialArgs = specialArgs;
               modules = [
-                perSystemModule
+                (perSystemArgsModule system)
                 modulePath
                 (
                   { config, ... }:
@@ -309,13 +310,13 @@ let
           ) homesNested;
         in
         eachSystem (
-          { pkgs, ... }:
+          { pkgs, system, ... }:
           {
             homeConfigurations = lib.mapAttrs (
               _name: homeData:
               mkHomeConfiguration {
                 inherit (homeData) modulePath username;
-                inherit pkgs;
+                inherit pkgs system;
               }
             ) homesFlat;
           }


### PR DESCRIPTION
this pr fixes #102, before this pr, standalone homemanager try's to use `config.nixpkgs.hostPlatform` to set `perSystem`, which doesn't exist on homemanager. this can easily be fixed since the standalone home configs are set in `legacyPackages` for every system, and thus we can get the current system from there.