### PR TITLE
filter packages by platform

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -589,7 +589,7 @@ let
                 }));
             in
             eachSystem (
-              { newScope, ... }: lib.mapAttrs (pname: { path, ... }: newScope { inherit pname; } path { }) entries
+              { newScope, system, ... }: filterPlatforms system (lib.mapAttrs (pname: { path, ... }: newScope { inherit pname; } path { }) entries)
             )
           );
 


### PR DESCRIPTION
First commit ensures that we only get an output per package on platforms that package supports.

~nix flake check does check all packages by default, so the `pkg-*` might be regarded as duplicates. On the other hand, they don't show up in the checks output, which probably means CI would skip them with buildbot-nix et al. :/~

~Shall we just drop the second commit and evaluate them twice?~