### PR TITLE
fix(formatter): interpret incoming data as null-char-separated

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -532,7 +532,7 @@ let
             fi
 
             # Use git to traverse since nixfmt doesn't have good traversal
-            git ls-files -z "$@" | grep --null '\.nix$' | xargs --null --no-run-if-empty nixfmt
+            git ls-files -z "$@" | grep --null --null-data '\.nix$' | xargs --null --no-run-if-empty nixfmt
           '';
         })
       );


### PR DESCRIPTION
Before this fix, grep was doing null-separated output. But it didn't
know input was also null-separated. Thus, when running on any repo with
more than 1 file, it would fail.
