### PR TITLE
Replace custom formatter with nixfmt-tree

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -507,34 +507,7 @@ let
     {
       formatter = eachSystem (
         { pkgs, perSystem, ... }:
-        perSystem.self.formatter or (pkgs.writeShellApplication {
-          name = "nixfmt-rfc-style";
-
-          runtimeInputs = [
-            pkgs.findutils
-            pkgs.gnugrep
-            pkgs.nixfmt-rfc-style
-          ];
-
-          text = ''
-            set -euo pipefail
-
-            # If no arguments are passed, default to formatting the whole project
-            # If git it not available, fallback on current directory.
-            if [[ $# = 0 ]]; then
-              prj_root=$(git rev-parse --show-toplevel 2>/dev/null || echo .)
-              set -- "$prj_root"
-            fi
-
-            # Not a git repo, or git is not installed. Fallback
-            if ! git rev-parse --is-inside-work-tree; then
-              exec nixfmt "$@"
-            fi
-
-            # Use git to traverse since nixfmt doesn't have good traversal
-            git ls-files -z "$@" | grep --null '\.nix$' | xargs --null --no-run-if-empty nixfmt
-          '';
-        })
+        perSystem.self.formatter or pkgs.nixfmt-tree
       );
 
       lib = tryImport (src + "/lib") specialArgs;


### PR DESCRIPTION
Now that 25.05 was released the custom formatter can be dropped