### PR TITLE
typo: docs system string syntax flipped in config.systems type

### DIFF
--- a/docs/content/getting-started/configuration.md
+++ b/docs/content/getting-started/configuration.md
@@ -39,7 +39,7 @@ Defines for which systems the project should be used and deployed on.
 
 Default: it will load the `inputs.systems` flake input, first from the current flake, and then fallback to the blueprint one. (see <https://github.com/nix-systems/default>).
 
-Type: list of `<kernel>-<arch>` strings.
+Type: list of `<arch>-<kernel>` strings.
 
 Example:
 


### PR DESCRIPTION
previous typo: `<kernel>-<arch>`
updated: `<arch>-<kernel>`