### PR TITLE
fix: missing code block in docs

### DIFF
--- a/docs/content/getting-started/folder_structure.md
+++ b/docs/content/getting-started/folder_structure.md
@@ -258,7 +258,7 @@ Expected return value:
 
 Flake outputs:
 
-> Depending on the system type returned, the flake outputs will be the same as detailed for NixOS, Darwin or System Manager above. But in general the value will lie in <type in camel-case>Configurations.<hostname>.
+> Depending on the system type returned, the flake outputs will be the same as detailed for NixOS, Darwin or System Manager above. But in general the value will lie in `<type in camel-case>Configurations.<hostname>`.
 
 ## `hosts/<hostname>/users/(<username>.nix|<username>/home-configuration.nix)`
 


### PR DESCRIPTION
Fixes the missing code block in the docs. So that the quote-block does not look like this:

<img width="927" height="205" alt="image" src="https://github.com/user-attachments/assets/fdce10b4-5b9b-4d22-a480-eaaac8879bb5" />

That was caused by my other PR yesterday