### PR TITLE
feat: allow nixpkgs package definitions

### DIFF
--- a/docs/content/getting-started/folder_structure.md
+++ b/docs/content/getting-started/folder_structure.md
@@ -353,7 +353,7 @@ maps to the "default" package.
 
 Inputs:
 
-The [per-system](#per-system) values, plus the `pname` attribute, where pname refers to the package name.
+The [per-system](#per-system) values, plus the `pname` attribute, where pname refers to the package name. To keep compatibility with the nixpkgs way of defining packages it is also possible for the inputs to be a subset of nixpkgs.
 
 Flake outputs:
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -54,7 +54,7 @@ let
                 overlays = nixpkgs.overlays or [ ];
               };
         in
-        lib.makeScope lib.callPackageWith (_: {
+        lib.makeScope lib.callPackageWith (_: pkgs // {
           inherit
             inputs
             perSystem


### PR DESCRIPTION
I found it quite annoying recently that it's not possible to copy a Nix package from nixpkgs directly into the `packages/` directory because Blueprint only accepts the custom argument attributes.

Nixpkgs defines packages in a way that the function argument attrset is direct subset of nixpkgs which Blueprint currently doesn't support. I found the fix for this quite easy.

To test this you can add [`hello.nix`](https://github.com/NixOS/nixpkgs/blob/7241bcbb4f099a66aafca120d37c65e8dda32717/pkgs/by-name/he/hello/package.nix) to your `packages/`. And run `git add packages/hello.nix && nix build .#hello`