### PR TITLE
feat: add treefmt-and-git-hooks template

### DIFF
--- a/templates/treefmt-and-git-hooks/.envrc
+++ b/templates/treefmt-and-git-hooks/.envrc
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Used by https://direnv.net
+
+# Automatically reload when this file changes
+watch_file nix/devshell.nix
+
+# Load `nix develop`
+use flake
+
+# Extend the environment with per-user overrides
+source_env_if_exists .envrc.local

--- a/templates/treefmt-and-git-hooks/.gitignore
+++ b/templates/treefmt-and-git-hooks/.gitignore
@@ -1,0 +1,9 @@
+# direnv
+.direnv/
+
+# nix
+result
+result-*
+
+# git-hooks.nix
+/.pre-commit-config.yaml

--- a/templates/treefmt-and-git-hooks/flake.nix
+++ b/templates/treefmt-and-git-hooks/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Flake with treefmt-nix and git-hooks.nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    blueprint.url = "github:numtide/blueprint";
+    blueprint.inputs.nixpkgs.follows = "nixpkgs";
+    treefmt.url = "github:numtide/treefmt-nix";
+    treefmt.inputs.nixpkgs.follows = "nixpkgs";
+    git-hooks.url = "github:cachix/git-hooks.nix";
+    git-hooks.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    inputs:
+    inputs.blueprint {
+      inherit inputs;
+      prefix = "nix";
+    };
+}

--- a/templates/treefmt-and-git-hooks/nix/checks/pre-commit-check.nix
+++ b/templates/treefmt-and-git-hooks/nix/checks/pre-commit-check.nix
@@ -1,0 +1,15 @@
+{ inputs, pkgs, ... }:
+let
+  treefmtEval = inputs.treefmt.lib.evalModule pkgs ../treefmt.nix;
+in
+inputs.git-hooks.lib.${pkgs.stdenv.hostPlatform.system}.run {
+  src = inputs.self;
+  hooks = {
+    nil.enable = true;
+    statix.enable = true;
+    treefmt = {
+      enable = true;
+      package = treefmtEval.config.build.wrapper;
+    };
+  };
+}

--- a/templates/treefmt-and-git-hooks/nix/devshell.nix
+++ b/templates/treefmt-and-git-hooks/nix/devshell.nix
@@ -1,0 +1,17 @@
+{ inputs, pkgs, ... }:
+let
+  pre-commit-check = import ./checks/pre-commit-check.nix { inherit inputs pkgs; };
+in
+pkgs.mkShell {
+  # Add build dependencies
+  packages = [ ];
+
+  # Add environment variables
+  env = { };
+
+  shellHook = ''
+    ${pre-commit-check.shellHook}
+
+    # Load custom bash code
+  '';
+}

--- a/templates/treefmt-and-git-hooks/nix/formatter.nix
+++ b/templates/treefmt-and-git-hooks/nix/formatter.nix
@@ -1,0 +1,5 @@
+{ inputs, pkgs, ... }:
+let
+  treefmtEval = inputs.treefmt.lib.evalModule pkgs ./treefmt.nix;
+in
+treefmtEval.config.build.wrapper

--- a/templates/treefmt-and-git-hooks/nix/treefmt.nix
+++ b/templates/treefmt-and-git-hooks/nix/treefmt.nix
@@ -1,0 +1,5 @@
+_: {
+  projectRootFile = "flake.nix";
+
+  programs.nixfmt.enable = true;
+}


### PR DESCRIPTION
## Summary
- Add a new template `treefmt-and-git-hooks` that sets up treefmt and git-hooks.nix with blueprint
- Includes formatter configuration with nixfmt
- Pre-commit hooks for nil, statix, and treefmt

## Template structure
```
templates/treefmt-and-git-hooks/
├── .envrc
├── .gitignore
├── flake.nix
└── nix/
    ├── checks/
    │   └── pre-commit-check.nix
    ├── devshell.nix
    ├── formatter.nix
    └── treefmt.nix
```