### PR TITLE
feat(lib): expose internal helpers

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,7 @@ let
   bpInputs = inputs;
   nixpkgs = bpInputs.nixpkgs;
   lib = nixpkgs.lib;
-
+in rec {
   # A generator for the top-level attributes of the flake.
   #
   # Designed to work with https://github.com/nix-systems
@@ -773,16 +773,6 @@ let
       expected = 1;
     };
   };
-in
-{
-  inherit
-    filterPlatforms
-    importDir
-    mkBlueprint
-    tests
-    tryImport
-    withPrefix
-    ;
 
   # Make this callable
   __functor = _: mkBlueprint;


### PR DESCRIPTION
A few internal helpers are actually useful for others.

```shell
$ nix eval .#lib --apply builtins.attrNames

# Before
[ "__functor" "filterPlatforms" "importDir" "mkBlueprint" "tests" "tryImport" "withPrefix" ]

# After
[ "__functor" "entriesPath" "filterPlatforms" "importDir" "importTomlFilesAt" "mkBlueprint" "mkBlueprint'" "mkEachSystem" "optionalPathAttrs" "tests" "tryImport" "withPrefix" ]
```


Expose them, so they can be reused:

- **`entriesPath`**: Helper to get the path to entries/files in a directory
- **`importTomlFilesAt`**: Imports TOML files from a specified directory and converts them to Nix attribute sets, with automatic name normalization
- **`mkBlueprint'`**: Internal implementation of `mkBlueprint` that creates the complete flake structure with all outputs (packages, configurations, modules, etc.)
- **`mkEachSystem`**: Creates a function that evaluates expressions per-system, handling cross-platform builds and system-specific configurations
- **`optionalPathAttrs`**: Returns attributes from a path if it exists, otherwise returns an empty set

@moduon MT-1075
