### PR TITLE
fix: ensure overlays are passed to all possible nixpkgs instances

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -205,17 +205,24 @@ in rec {
           imports = [ (perSystemArgsModule config.nixpkgs.hostPlatform) ];
         };
 
+      # Share the per-system pkgs blueprint already instantiated (with the
+      # configured nixpkgs.config/overlays applied) instead of having the
+      # NixOS/nix-darwin module system import nixpkgs a second time with
+      # the same settings.
+      #
+      # Only injected when blueprint actually has config/overlays to
+      # propagate; otherwise hosts keep full control of their nixpkgs.*
+      # options. mkDefault so a host can still set its own nixpkgs.pkgs.
       nixpkgsConfigModule =
-        { lib, ... }:
-        {
-          nixpkgs =
-            (lib.optionalAttrs ((nixpkgs.config or { }) != { }) {
-              config = nixpkgs.config;
-            })
-            // (lib.optionalAttrs ((nixpkgs.overlays or [ ]) != [ ]) {
-              overlays = nixpkgs.overlays;
-            });
-        };
+        if (nixpkgs.config or { }) == { } && (nixpkgs.overlays or [ ]) == [ ] then
+          { }
+        else
+          (
+            { config, lib, ... }:
+            {
+              nixpkgs.pkgs = lib.mkDefault systemArgs.${config.nixpkgs.hostPlatform.system}.pkgs;
+            }
+          );
 
       home-manager =
         inputs.home-manager

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -205,6 +205,18 @@ in rec {
           imports = [ (perSystemArgsModule config.nixpkgs.hostPlatform) ];
         };
 
+      nixpkgsConfigModule =
+        { lib, ... }:
+        {
+          nixpkgs =
+            (lib.optionalAttrs ((nixpkgs.config or { }) != { }) {
+              config = nixpkgs.config;
+            })
+            // (lib.optionalAttrs ((nixpkgs.overlays or [ ]) != [ ]) {
+              overlays = nixpkgs.overlays;
+            });
+        };
+
       home-manager =
         inputs.home-manager
           or (throw ''home configurations require Home Manager. To fix this, add `inputs.home-manager.url = "github:nix-community/home-manager";` to your flake'');
@@ -351,6 +363,7 @@ in rec {
             class = "nixos";
             value = inputs.nixpkgs.lib.nixosSystem {
               modules = [
+                nixpkgsConfigModule
                 perSystemModule
                 path
               ] ++ mkHomeUsersModule hostName home-manager.nixosModules.default;
@@ -371,6 +384,7 @@ in rec {
               class = "nixos";
               value = nixos-raspberrypi.lib.nixosSystem {
                 modules = [
+                  nixpkgsConfigModule
                   perSystemModule
                   path
                 ]
@@ -393,6 +407,7 @@ in rec {
               class = "nix-darwin";
               value = nix-darwin.lib.darwinSystem {
                 modules = [
+                  nixpkgsConfigModule
                   perSystemModule
                   path
                 ] ++ mkHomeUsersModule hostName home-manager.darwinModules.default;


### PR DESCRIPTION
Tried to apply an overlay to get around the current boost 1.89 situation on nixpkgs only to find it wasn't actually being applied everywhere and neither was nixpkgs.config. Added an extra module to ensure that they are passed to `config.nixpkgs` too.