### PR TITLE
fix: replace deprecated nixpkgs.hostPlatform with nixpkgs.system

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -190,19 +190,19 @@ in rec {
       perSystemModule =
         { config, lib, ... }:
         {
-          imports = [ (perSystemArgsModule config.nixpkgs.hostPlatform.system) ];
+          imports = [ (perSystemArgsModule config.nixpkgs.system) ];
         };
 
       perSystemHMModule =
         { osConfig, ... }:
         {
-          imports = [ (perSystemArgsModule osConfig.nixpkgs.hostPlatform.system) ];
+          imports = [ (perSystemArgsModule osConfig.nixpkgs.system) ];
         };
 
       perSystemSMModule =
         { config, lib, ... }:
         {
-          imports = [ (perSystemArgsModule config.nixpkgs.hostPlatform) ];
+          imports = [ (perSystemArgsModule config.nixpkgs.system) ];
         };
 
       home-manager =


### PR DESCRIPTION
`nixpkgs.hostPlatform` is deprecated and triggers evaluation warnings:
```
evaluation warning: 'hostPlatform' has been renamed to/replaced by 'stdenv.hostPlatform'
```

Replace with `nixpkgs.system` in `lib/default.nix` lines 193, 199, 205.

Verified that `nixpkgs.system` evaluates correctly in a NixOS module context.