### PR TITLE
feat(lib): add mkPackagesFor for overlay-friendly package sets

### DIFF
--- a/docs/content/getting-started/folder_structure.md
+++ b/docs/content/getting-started/folder_structure.md
@@ -387,6 +387,35 @@ Flake outputs:
 
 To consume a package inside a host from the same flake, `perSystem.self.<pname>`
 
+#### Exposing packages as an overlay
+
+`packages.<system>` is built against blueprint's own `pkgs` (derived from
+`inputs.nixpkgs` plus any `nixpkgs.config`/`nixpkgs.overlays` you set). If a
+consumer applies your packages as a nixpkgs overlay, they usually want them
+built against *their* nixpkgs instance instead, so that dependencies are
+shared and only one nixpkgs is evaluated.
+
+For that, blueprint also emits a `mkPackagesFor` function that re-loads the
+`packages/` tree against a caller-supplied `pkgs`:
+
+```nix
+outputs = inputs:
+  let
+    bp = inputs.blueprint { inherit inputs; };
+  in
+  bp // {
+    overlays.default = final: _prev: {
+      myproject = bp.mkPackagesFor final;
+    };
+  };
+```
+
+Each package sees the same scope arguments (`pkgs`, `flake`, `inputs`,
+`system`, `perSystem`, `pname`) as in `packages.<system>`; only `pkgs` is
+swapped for the overlay's `final`. `perSystem.self` resolves within this set,
+so packages that reference each other stay consistent with the caller's
+nixpkgs.
+
 #### `default.nix` or top-level `package.nix`
 
 Takes the "per-system" arguments. On top of this, it also takes a `pname` argument.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -33,15 +33,10 @@ in rec {
       systemArgs = lib.genAttrs systems (
         system:
         let
-          # Resolve the packages for each input.
-          perSystem = lib.mapAttrs (
-            name: flake:
-            # For self, we need to treat packages differently, see above
-            if name == "self" then
-              flake.legacyPackages.${system} or { } // unfilteredPackages.${system}
-            else
-              flake.legacyPackages.${system} or { } // flake.packages.${system} or { }
-          ) inputs;
+          perSystem = mkPerSystem {
+            inherit inputs system;
+            selfPackages = unfilteredPackages.${system};
+          };
 
           # Handle nixpkgs specially.
           pkgs =
@@ -143,6 +138,24 @@ in rec {
         value = value;
       }
     );
+
+  # Resolve perSystem.<input> for every flake input. For inputs.self,
+  # `selfPackages` is merged instead of `self.packages.${system}` so the
+  # caller can break the packages → filterPlatforms → perSystem.self
+  # → packages cycle (see the comment on `unfilteredPackages` in
+  # mkEachSystem) and, in the overlay case, point intra-set references
+  # at the set built against the caller's nixpkgs.
+  mkPerSystem =
+    {
+      inputs,
+      system,
+      selfPackages,
+    }:
+    lib.mapAttrs (
+      name: input:
+      (input.legacyPackages.${system} or { })
+      // (if name == "self" then selfPackages else input.packages.${system} or { })
+    ) inputs;
 
   filterPlatforms =
     system: attrs:
@@ -507,29 +520,56 @@ in rec {
           )
         );
 
+      packageEntries =
+        (optionalPathAttrs (src + "/packages") (path: importDir path lib.id))
+        // (optionalPathAttrs (src + "/package.nix") (path: {
+          default = {
+            inherit path;
+          };
+        }))
+        // (optionalPathAttrs (src + "/formatter.nix") (path: {
+          formatter = {
+            inherit path;
+          };
+        }));
+
       # See the comment in mkEachSystem
       unfilteredPackages =
         lib.traceIf (builtins.pathExists (src + "/pkgs")) "blueprint: the /pkgs folder is now /packages"
-          (
-            let
-              entries =
-                (optionalPathAttrs (src + "/packages") (path: importDir path lib.id))
-                // (optionalPathAttrs (src + "/package.nix") (path: {
-                  default = {
-                    inherit path;
-                  };
-                }))
-                // (optionalPathAttrs (src + "/formatter.nix") (path: {
-                  formatter = {
-                    inherit path;
-                  };
-                }));
-            in
-            eachSystem (
-              { newScope, system, ... }:
-              lib.mapAttrs (pname: { path, ... }: newScope { inherit pname; } path { }) entries
-            )
-          );
+          (eachSystem ({ pkgs, ... }: mkPackagesFor pkgs));
+
+      # Load the packages/ tree against a given nixpkgs instance.
+      # Packages get the same scope arguments as via systemArgs (pkgs,
+      # flake, inputs, system, perSystem, pname). perSystem.self resolves
+      # within this scope so intra-set references stay consistent with
+      # the supplied nixpkgs.
+      #
+      # Used internally for packages.<system> (with blueprint's own
+      # pkgs) and exposed so consumers can build an overlay that uses
+      # their pkgs instead.
+      mkPackagesFor =
+        pkgs:
+        let
+          system = pkgs.stdenv.hostPlatform.system;
+          scope = lib.makeScope lib.callPackageWith (self: {
+            inherit
+              inputs
+              flake
+              pkgs
+              system
+              ;
+            perSystem = mkPerSystem {
+              inherit inputs system;
+              selfPackages = self.packageSet;
+            };
+            # NB: lib.makeScope reserves `packages` for its generator
+            # function, so the result lives under a different name.
+            packageSet = lib.mapAttrs (
+              pname: { path, ... }: self.newScope { inherit pname; } path { }
+            ) packageEntries;
+          });
+        in
+        scope.packageSet;
     in
     # FIXME: maybe there are two layers to this. The blueprint, and then the mapping to flake outputs.
     {
@@ -622,6 +662,8 @@ in rec {
 
       # See the comment in mkEachSystem
       packages = lib.mapAttrs filterPlatforms unfilteredPackages;
+
+      inherit mkPackagesFor;
 
       # Defining homeConfigurations under legacyPackages allows the home-manager CLI
       # to automatically detect the right output for the current system without


### PR DESCRIPTION
## Problem

A blueprint flake that wants to expose its `packages/` as a nixpkgs overlay
currently has no good option. The obvious

```nix
overlays.default = final: _: {
  foo = self.packages.${final.stdenv.hostPlatform.system};
};
```

doesn't build anything against `final` — it hands back the set blueprint
already built from `inputs.nixpkgs` (with whatever `nixpkgs.config`/`overlays`
the flake configured). The consumer ends up evaluating a second, independent
nixpkgs instance for those packages. `inputs.nixpkgs.follows` doesn't help; it
only changes which source gets re-imported, but still imports a second instance.

Concretely, in a NixOS config consuming `llm-agents.nix` (which uses exactly
this pattern), this accounts for ~2M extra function calls / ~9% of total eval
time per host.

## Change

Add a `mkPackagesFor` output that reloads the `packages/` tree against a
caller-supplied `pkgs`. Packages see the same scope arguments as in
`packages.<system>` (`pkgs`, `flake`, `inputs`, `system`, `perSystem`,
`pname`); only `pkgs` is swapped. `perSystem.self` resolves within the new
scope so intra-set references stay on the caller's nixpkgs.

```nix
outputs = inputs:
  let bp = inputs.blueprint { inherit inputs; };
  in bp // {
    overlays.default = final: _prev: {
      foo = bp.mkPackagesFor final;
    };
  };
```

`unfilteredPackages` is redefined in terms of `mkPackagesFor`, so there is a
single loader for the `packages/` tree. Existing outputs are unchanged
(verified: identical drv hashes for `packages` and `devShells` via
llm-agents.nix as a fixture).

Related: #90, numtide/llm-agents.nix#1172
