### PR TITLE
fix(templates): set fileSystems."/".fsType in nixos example

### DIFF
--- a/templates/nixos-and-darwin-shared-homes/hosts/my-nixos/configuration.nix
+++ b/templates/nixos-and-darwin-shared-homes/hosts/my-nixos/configuration.nix
@@ -10,7 +10,10 @@
 
   # for testing purposes only, remove on bootable hosts.
   boot.loader.grub.enable = pkgs.lib.mkDefault false;
-  fileSystems."/".device = pkgs.lib.mkDefault "/dev/null";
+  fileSystems."/" = {
+    device = pkgs.lib.mkDefault "/dev/null";
+    fsType = pkgs.lib.mkDefault "ext4";
+  };
 
   system.stateVersion = "25.05"; # initial nixos state
 }


### PR DESCRIPTION
NixOS/nixpkgs#444829 (merged 2026-04-06) dropped the `"auto"` default for
`fileSystems.<name>.fsType`. The `nixos-and-darwin-shared-homes` template
only sets `device` for its dummy `/`, so `nix flake check` now fails with

```
error: The option `fileSystems."/".fsType' was accessed but has no value
defined. Try setting the option.
```

The template has no `flake.lock` and tracks `nixos-unstable`, so this broke
`main` in place — the last CI run on `main` (Feb 18) predates the nixpkgs
change.
